### PR TITLE
Adding witnesses + Python ctypes wrapper.

### DIFF
--- a/.github/workflows/github-opengjk-examples.yml
+++ b/.github/workflows/github-opengjk-examples.yml
@@ -47,6 +47,42 @@ jobs:
       - run: cd examples/cython/ && python3 setup.py build_ext --inplace && python3 pygjk_trial.py
       - run: cd examples/cython/ && pytest test.py
 
+  PythonCTypes:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Python ${{matrix.python_version}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.python_version}}
+
+      - name: Get dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: CMake config
+        run: cmake -B ${{github.workspace}}/build
+        env:
+          BUILD_CTYPES: 1
+          CMAKE_BUILD_TYPE: Release
+
+      - name: CMake build
+        working-directory: ${{github.workspace}}/build
+        run: make
+
+      - name: Python build
+        working-directory: ${{github.workspace}}/examples/python_ctypes/
+        run: pip install -e .[test]
+
+      - name: Python test
+        working-directory: ${{github.workspace}}/examples/python_ctypes/
+        run: pytest -vv
+
   CSharp:
     runs-on: ubuntu-latest
     container: mono:latest

--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,11 @@ callgrind.out.*
 
 .zig-cache/
 zig-out/
+
+# Python
+.env
+*.egg-info
+*.whl
+
+# VS Code
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,19 @@
 #  FOR A PARTICULAR PURPOSE. See GNU General Public License for details.           #
 
 # User options . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-option(BUILD_EXAMPLE "Build demo"        ON )
-option(BUILD_MONO    "Build C# example"  OFF)
+option(BUILD_EXAMPLE "Build demo"                        ON )
+option(BUILD_MONO    "Build C# example"                  OFF)
+option(BUILD_CTYPES  "Expose symbols for Python cytpes"  OFF)
 
 # CMake setup  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-cmake_minimum_required(VERSION          3.0) # You can downgrade to 2.8, but I don't maintain it anymore
+cmake_minimum_required(VERSION          3.5) # You can downgrade to 2.8, but I don't maintain it anymore
 cmake_policy(SET CMP0048                NEW) 
 cmake_policy(SET CMP0063                NEW) # Visibility of preset and hidden lines on shared libs
 
 set( CMAKE_C_VISIBILITY_PRESET           hidden)
 set( CMAKE_VISIBILITY_INLINES_HIDDEN     FALSE)
 set( CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS    ON)
+set( CMAKE_EXPORT_COMPILE_COMMANDS       ON)
 
 # Project setup  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
 set(GK_VERSION_MAJOR                      3)
@@ -61,6 +63,10 @@ elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 # Target . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
+
+if(BUILD_CTYPES)
+    set( CMAKE_C_VISIBILITY_PRESET           default)
+endif(BUILD_CTYPES)
 
 if(BUILD_MONO)
     set( CMAKE_C_VISIBILITY_PRESET           default)
@@ -95,6 +101,15 @@ set_target_properties(obj_openGJK
 )
 
 add_library(opengjk_ce SHARED $<TARGET_OBJECTS:obj_openGJK>)
+
+if (BUILD_CTYPES)
+    add_custom_command(
+        TARGET opengjk_ce
+        COMMAND ${CMAKE_COMMAND} -E copy
+        "$<TARGET_FILE:opengjk_ce>"
+        "${CMAKE_CURRENT_SOURCE_DIR}/examples/python_ctypes/src/pyopengjk"
+    )
+endif(BUILD_CTYPES)
 
 # Build demo . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
 if(BUILD_EXAMPLE)

--- a/examples/c/main.c
+++ b/examples/c/main.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include "openGJK/openGJK.h"
 
@@ -88,7 +89,7 @@ readinput(const char* inputfile, gkFloat*** pts, int* out) {
 int
 main() {
   /* Squared distance computed by openGJK.                                 */
-  gkFloat dd;
+  gkFloat dd, dx, dy, dz;
   /* Structure of simplex used by openGJK.                                 */
   gkSimplex s;
   /* Number of vertices defining body 1 and body 2, respectively.          */
@@ -127,6 +128,13 @@ main() {
 
   /* Print distance between objects. */
   printf("Distance between bodies %f\n", dd);
+  printf("Witnesses: (%f, %f, %f) and (%f, %f, %f)\n",
+         s.witnesses[0][0], s.witnesses[0][1], s.witnesses[0][2],
+         s.witnesses[1][0], s.witnesses[1][1], s.witnesses[1][2]);
+  dx = s.witnesses[0][0] - s.witnesses[1][0];
+  dy = s.witnesses[0][1] - s.witnesses[1][1];
+  dz = s.witnesses[0][2] - s.witnesses[1][2];
+  printf("Distance between witnesses %f\n", sqrt(dx * dx + dy * dy + dz * dz));
 
   /* Free memory */
   for (int i = 0; i < bd1.numpoints; i++) {

--- a/examples/python_ctypes/README.md
+++ b/examples/python_ctypes/README.md
@@ -1,0 +1,82 @@
+# Python `ctypes` wrapper
+
+This wrapper uses `ctypes` to wrap the full C API for use from Python.
+
+## Getting Started
+
+To start, build the project with `BUILD_CTYPES` enabled. From the
+project root:
+
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_CTYPES=1
+    cmake --build .
+    cd ../examples/python_ctypes
+    ls src/pyopengjk/
+
+At this point you should see either one of `libopengjk_ce.so`,
+`opengjk_ce.dll`, or `libopengjk_ce.dylib` depending on your OS.
+If not, then something has gone wrong with the build process. Make
+certain `BUILD_CTYPES` is enabled, as that should copy the shared
+library. If present, then proceed with creating a virtual environment
+(posix version shown below):
+
+    python -m venv .env
+    . .env/bin/activate
+    (.env) pip install --upgrade pip
+    (.env) pip install -e .[test]
+    (.env) pytest test/
+    (.env) pip wheel .
+
+The tests should run (and pass), and then a wheel will be built that
+you can install and use in other Python environments.
+
+## Usage
+
+The API exposes the `compute_minimum_distance` function, taking as an
+argument two lists of vertices. A `Vertex` type is provided for
+convenience, for example:
+
+```python
+vertices0 = [
+    Point3(0.0, 5.5, 0.0),
+    Point3(2.3, 1.0, -2.0),
+    Point3(8.1, 4.0, 2.4),
+    Point3(4.3, 5.0, 2.2),
+    Point3(2.5, 1.0, 2.3),
+    Point3(7.1, 1.0, 2.4),
+    Point3(1.0, 1.5, 0.3),
+    Point3(3.3, 0.5, 0.3),
+    Point3(6.0, 1.4, 0.2)
+]
+
+vertices1 = [
+    Point3(0.0, -5.5, 0.0),
+    Point3(-2.3, -1.0, 2.0),
+    Point3(-8.1, -4.0, -2.4),
+    Point3(-4.3, -5.0, -2.2),
+    Point3(-2.5, -1.0, -2.3),
+    Point3(-7.1, -1.0, -2.4),
+    Point3(-1.0, -1.5, -0.3),
+    Point3(-3.3, -0.5, -0.3),
+    Point3(-6.0, -1.4, -0.2)
+]
+
+distance, simplex = compute_minimum_distance(vertices0, vertices1)
+print(f"Minimum distance: {distance}")
+print("Witness points:")
+print(simplex.witnesses[0])
+print(simplex.witnesses[1])
+```
+
+will produce the output:
+
+    Minimum distance: 3.653649722294501
+    Witness points:
+    Point3(x=1.0251728907330566, y=1.4903181189488242, z=0.2554633471645919)
+    Point3(x=-1.0251728907330566, y=-1.4903181189488242, z=-0.2554633471645919)
+
+However, any "list of lists" will suffice, *i.e.* a (N, 3) `numpy` array
+will work just as well. The simplex that is returned contains
+the final simplex vertices and their source indices in addition to
+the witness points.

--- a/examples/python_ctypes/example.py
+++ b/examples/python_ctypes/example.py
@@ -1,0 +1,37 @@
+from pyopengjk import compute_minimum_distance, Point3
+
+
+def main():
+    vertices0 = [
+        Point3(0.0, 5.5, 0.0),
+        Point3(2.3, 1.0, -2.0),
+        Point3(8.1, 4.0, 2.4),
+        Point3(4.3, 5.0, 2.2),
+        Point3(2.5, 1.0, 2.3),
+        Point3(7.1, 1.0, 2.4),
+        Point3(1.0, 1.5, 0.3),
+        Point3(3.3, 0.5, 0.3),
+        Point3(6.0, 1.4, 0.2)
+    ]
+
+    vertices1 = [
+        Point3(0.0, -5.5, 0.0),
+        Point3(-2.3, -1.0, 2.0),
+        Point3(-8.1, -4.0, -2.4),
+        Point3(-4.3, -5.0, -2.2),
+        Point3(-2.5, -1.0, -2.3),
+        Point3(-7.1, -1.0, -2.4),
+        Point3(-1.0, -1.5, -0.3),
+        Point3(-3.3, -0.5, -0.3),
+        Point3(-6.0, -1.4, -0.2)
+    ]
+
+    distance, simplex = compute_minimum_distance(vertices0, vertices1)
+    print(f"Minimum distance: {distance}")
+    print("Witness points:")
+    print(simplex.witnesses[0])
+    print(simplex.witnesses[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python_ctypes/pyproject.toml
+++ b/examples/python_ctypes/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name =  "pyopengjk"
+version = "0.1.0"
+authors = [
+    { name="Mattia Montanari", email="mattia.montanari@it.ox.ac.uk" },
+    { name="Matthew Johnson", email="mj293@cam.ac.uk" },
+]
+description = "A fast and robust C implementation of the Gilbert-Johnson-Keerthi (GJK) algorithm"
+dependencies = [
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "numpy",
+    "scipy"
+
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+pyopengjk = ["*.dll", "*.so", "*.dylib"]

--- a/examples/python_ctypes/pyproject.toml
+++ b/examples/python_ctypes/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 description = "A fast and robust C implementation of the Gilbert-Johnson-Keerthi (GJK) algorithm"
 dependencies = [
 ]
+readme = "README.md"
 
 [project.optional-dependencies]
 test = [

--- a/examples/python_ctypes/src/pyopengjk/__init__.py
+++ b/examples/python_ctypes/src/pyopengjk/__init__.py
@@ -1,0 +1,9 @@
+"""Python wrapper for openGJK.
+
+openGJK is a fast and robust C implementation of the
+Gilbert-Johnson-Keerthi (GJK) algorithm.
+"""
+
+from .opengjk import compute_minimum_distance, Point3, Simplex, DistanceResult
+
+__all__ = ["compute_minimum_distance", "Point3", "Simplex", "DistanceResult"]

--- a/examples/python_ctypes/src/pyopengjk/opengjk.py
+++ b/examples/python_ctypes/src/pyopengjk/opengjk.py
@@ -1,0 +1,88 @@
+import ctypes
+from ctypes import Structure, POINTER, c_int, c_double
+import os
+from typing import NamedTuple, Tuple, List
+
+
+class POLYTOPE(Structure):
+    _fields_ = [
+        ("numpoints", c_int),
+        ("s", c_double * 3),
+        ("s_idx", c_int),
+        ("coord", POINTER(POINTER(c_double)))
+    ]
+
+
+class SIMPLEX(Structure):
+    _fields_ = [
+        ("nvrtx", c_int),
+        ("vrtx", (c_double * 3) * 4),
+        ("vrtx_idx", (c_int * 2) * 4),
+        ("witnesses", (c_double * 3) * 2)
+    ]
+
+
+module_dir = os.path.dirname(__file__)
+if os.path.exists(os.path.join(module_dir, "opengjk_ce.dll")):
+    path = os.path.join(module_dir, "opengjk_ce.dll")
+elif os.path.exists(os.path.join(module_dir, "libopengjk_ce.so")):
+    path = os.path.join(module_dir, "libopengjk_ce.so")
+elif os.path.exists(os.path.join(module_dir, "libopengjk_ce.dylib")):
+    path = os.path.join(module_dir, "libopengjk_ce.dylib")
+else:
+    raise RuntimeError("Could not find rego_shared library")
+
+
+opengjk = ctypes.cdll.LoadLibrary(path)
+
+opengjk.compute_minimum_distance.restype = ctypes.c_double
+opengjk.compute_minimum_distance.argtypes = [POLYTOPE,
+                                             POLYTOPE,
+                                             POINTER(SIMPLEX)]
+
+
+Point3 = NamedTuple("Point3", [("x", float), ("y", float), ("z", float)])
+
+Simplex = NamedTuple("Simplex", [("vertices", List[Point3]),
+                                 ("indices", List[Tuple[int, int]]),
+                                 ("witnesses", Tuple[Point3, Point3])])
+
+DistanceResult = NamedTuple("Result", [("distance", float),
+                                       ("simplex", Simplex)])
+
+
+def compute_minimum_distance(vertices0: List[Point3],
+                             vertices1: List[Point3]) -> DistanceResult:
+    """Compute the minimum distance between two polytopes.
+
+    Args:
+        vertices0: Vertices of the first polytope.
+        vertices1: Vertices of the second polytope.
+
+    Returns:
+        DistanceResult: A named tuple containing the distance and the final
+                        simplex, which contains the points on the polytopes
+                        that are closest to each other.
+    """
+    polytope0 = POLYTOPE()
+    polytope0.numpoints = len(vertices0)
+    polytope0.s = (c_double * 3)(0, 0, 0)
+    polytope0.coord = (POINTER(c_double) * len(vertices0))()
+    for i, vertex in enumerate(vertices0):
+        polytope0.coord[i] = (c_double * 3)(*vertex)
+
+    polytope1 = POLYTOPE()
+    polytope1.numpoints = len(vertices1)
+    polytope1.s = (c_double * 3)(0, 0, 0)
+    polytope1.coord = (POINTER(c_double) * len(vertices1))()
+    for i, vertex in enumerate(vertices1):
+        polytope1.coord[i] = (c_double * 3)(*vertex)
+
+    simplex = SIMPLEX()
+    simplex.nvrtx = 0
+    distance = opengjk.compute_minimum_distance(polytope0, polytope1, simplex)
+    vertices = [Point3(*simplex.vrtx[i]) for i in range(simplex.nvrtx)]
+    indices = [(simplex.vrtx_idx[i][0], simplex.vrtx_idx[i][1])
+               for i in range(simplex.nvrtx)]
+    witnesses = (Point3(*simplex.witnesses[0]), Point3(*simplex.witnesses[1]))
+    return DistanceResult(distance, Simplex(vertices, indices, witnesses))

--- a/examples/python_ctypes/test/test_min_distance.py
+++ b/examples/python_ctypes/test/test_min_distance.py
@@ -1,3 +1,4 @@
+import math
 from pyopengjk import compute_minimum_distance, Simplex
 from scipy.spatial.transform import Rotation as R
 import numpy as np
@@ -27,7 +28,7 @@ def check_witnesses(expected_distance: float, simplex: Simplex):
     witness0 = np.array(simplex.witnesses[0], np.float64)
     witness1 = np.array(simplex.witnesses[1], np.float64)
     actual_distance = np.linalg.norm(witness0-witness1)
-    assert pytest.approx(expected_distance) == actual_distance
+    assert pytest.approx(expected_distance, abs=1e-5) == actual_distance
 
 
 @pytest.mark.parametrize("delta", [0.1, 1e-12, 0, -2])
@@ -186,7 +187,9 @@ def test_random_objects():
             for k in range(1000):
                 arr1 = np.random.rand(i, 3)
                 arr2 = np.random.rand(j, 3)
-                compute_minimum_distance(arr1, arr2)
+                distance, simplex = compute_minimum_distance(arr1, arr2)
+                if not math.isnan(distance):
+                    check_witnesses(distance, simplex)
 
 
 def test_large_random_objects():
@@ -195,4 +198,10 @@ def test_large_random_objects():
             for k in range(1000):
                 arr1 = 10000.0*np.random.rand(i, 3)
                 arr2 = 10000.0*np.random.rand(j, 3)
-                compute_minimum_distance(arr1, arr2)
+                distance, simplex = compute_minimum_distance(arr1, arr2)
+                if not math.isnan(distance):
+                    check_witnesses(distance, simplex)
+
+
+if __name__ == "__main__":
+    test_random_objects()

--- a/examples/python_ctypes/test/test_min_distance.py
+++ b/examples/python_ctypes/test/test_min_distance.py
@@ -1,0 +1,198 @@
+from pyopengjk import compute_minimum_distance, Simplex
+from scipy.spatial.transform import Rotation as R
+import numpy as np
+import pytest
+
+
+def settol():
+    return 1e-12
+
+
+def distance_point_to_line_3D(P1, P2, point):
+    """
+    distance from point to line
+    """
+    return np.linalg.norm(np.cross(P2-P1, P1-point))/np.linalg.norm(P2-P1)
+
+
+def distance_point_to_plane_3D(P1, P2, P3, point):
+    """
+    Distance from point to plane
+    """
+    return np.abs(np.dot(np.cross(P2-P1, P3-P1) /
+                         np.linalg.norm(np.cross(P2-P1, P3-P1)), point-P2))
+
+
+def check_witnesses(expected_distance: float, simplex: Simplex):
+    witness0 = np.array(simplex.witnesses[0], np.float64)
+    witness1 = np.array(simplex.witnesses[1], np.float64)
+    actual_distance = np.linalg.norm(witness0-witness1)
+    assert pytest.approx(expected_distance) == actual_distance
+
+
+@pytest.mark.parametrize("delta", [0.1, 1e-12, 0, -2])
+def test_line_point_distance(delta):
+    line = np.array([[0.1, 0.2, 0.3], [0.5, 0.8, 0.7]], dtype=np.float64)
+    point_on_line = line[0] + 0.27*(line[1]-line[0])
+    normal = np.cross(line[0], line[1])
+    point = point_on_line + delta * normal
+    distance, simplex = compute_minimum_distance(line, [point])
+    actual_distance = distance_point_to_line_3D(line[0], line[1], point)
+    check_witnesses(distance, simplex)
+    print(distance, actual_distance)
+    assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("delta", [0.1, 1e-12, 0])
+def test_line_line_distance(delta):
+    line = np.array([[-0.5, -0.7, -0.3], [1, 2, 3]], dtype=np.float64)
+    point_on_line = line[0] + 0.38*(line[1]-line[0])
+    normal = np.cross(line[0], line[1])
+    point = point_on_line + delta * normal
+    line_2 = np.array([point, [2, 5, 6]], dtype=np.float64)
+    distance, simplex = compute_minimum_distance(line, line_2)
+    actual_distance = distance_point_to_line_3D(
+        line[0], line[1], line_2[0])
+    check_witnesses(distance, simplex)
+    print(distance, actual_distance)
+    assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("delta", [0.1**(3*i) for i in range(6)])
+def test_tri_distance(delta):
+    tri_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
+    tri_2 = np.array([[1, delta, 0], [3, 1.2, 0], [
+        1, 1, 0]], dtype=np.float64)
+    P1 = tri_1[2]
+    P2 = tri_1[1]
+    point = tri_2[0]
+    actual_distance = distance_point_to_line_3D(P1, P2, point)
+    distance, simplex = compute_minimum_distance(tri_1, tri_2)
+    print("Computed distance ", distance, "Actual distance ", actual_distance)
+    check_witnesses(distance, simplex)
+    assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("delta", [0.1*0.1**(3*i) for i in range(6)])
+def test_quad_distance2d(delta):
+    quad_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0],
+                       [1, 1, 0]], dtype=np.float64)
+    quad_2 = np.array([[0, 1+delta, 0], [2, 2, 0],
+                       [2, 4, 0], [4, 4, 0]], dtype=np.float64)
+    P1 = quad_1[2]
+    P2 = quad_1[3]
+    point = quad_2[0]
+    actual_distance = distance_point_to_line_3D(P1, P2, point)
+    distance, simplex = compute_minimum_distance(quad_1, quad_2)
+    check_witnesses(distance, simplex)
+    print("Computed distance ", distance, "Actual distance ", actual_distance)
+
+    assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("delta", [1*0.5**(3*i) for i in range(7)])
+def test_tetra_distance_3d(delta):
+    tetra_1 = np.array([[0, 0, 0.2], [1, 0, 0.1], [0, 1, 0.3],
+                        [0, 0, 1]], dtype=np.float64)
+    tetra_2 = np.array([[0, 0, -3], [1, 0, -3], [0, 1, -3],
+                        [0.5, 0.3, -delta]], dtype=np.float64)
+    actual_distance = distance_point_to_plane_3D(tetra_1[0], tetra_1[1],
+                                                 tetra_1[2], tetra_2[3])
+    distance, simplex = compute_minimum_distance(tetra_1, tetra_2)
+    check_witnesses(distance, simplex)
+    print("Computed distance ", distance, "Actual distance ", actual_distance)
+
+    assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("delta", [(-1)**i*np.sqrt(2)*0.1**(3*i)
+                                   for i in range(6)])
+def test_tetra_collision_3d(delta):
+    tetra_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0],
+                        [0, 0, 1]], dtype=np.float64)
+    tetra_2 = np.array([[0, 0, -3], [1, 0, -3], [0, 1, -3],
+                        [0.5, 0.3, -delta]], dtype=np.float64)
+    actual_distance = distance_point_to_plane_3D(tetra_1[0], tetra_1[1],
+                                                 tetra_1[2], tetra_2[3])
+    distance, simplex = compute_minimum_distance(tetra_1, tetra_2)
+
+    if delta < 0:
+        assert (np.isclose(distance, 0, atol=settol()))
+    else:
+        print("Computed distance ", distance,
+              "Actual distance ", actual_distance)
+        assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("delta", [0, -0.1, -0.49, -0.51])
+def test_hex_collision_3d(delta):
+    hex_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],
+                      [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]],
+                     dtype=np.float64)
+    P0 = np.array([1.5+delta, 1.5+delta, 0.5], dtype=np.float64)
+    P1 = np.array([2, 2, 1], dtype=np.float64)
+    P2 = np.array([2, 1.25, 0.25], dtype=np.float64)
+    P3 = P1 + P2 - P0
+    quad_1 = np.array([P0, P1, P2, P3], dtype=np.float64)
+    n = (np.cross(quad_1[1]-quad_1[0], quad_1[2]-quad_1[0]) /
+         np.linalg.norm(
+        np.cross(quad_1[1]-quad_1[0],
+                 quad_1[2]-quad_1[0])))
+    quad_2 = quad_1 + n
+    hex_2 = np.zeros((8, 3), dtype=np.float64)
+    hex_2[:4, :] = quad_1
+    hex_2[4:, :] = quad_2
+    actual_distance = np.linalg.norm(
+        np.array([1, 1, P0[2]], dtype=np.float64)-hex_2[0])
+    distance, simplex = compute_minimum_distance(hex_1, hex_2)
+    check_witnesses(distance, simplex)
+
+    if P0[0] < 1:
+        assert (np.isclose(distance, 0, atol=settol()))
+    else:
+        print("Computed distance ", distance,
+              "Actual distance ", actual_distance)
+        assert (np.isclose(distance, actual_distance, atol=settol()))
+
+
+@pytest.mark.parametrize("c0", [0, 1, 2, 3])
+@pytest.mark.parametrize("c1", [0, 1, 2, 3])
+def test_cube_distance(c0, c1):
+    cubes = [np.array([[-1, -1, -1], [1, -1, -1], [-1, 1, -1], [1, 1, -1],
+                       [-1, -1, 1], [1, -1, 1], [-1, 1, 1], [1, 1, 1]],
+                      dtype=np.float64)]
+
+    r = R.from_euler('z', 45, degrees=True)
+    cubes.append(r.apply(cubes[0]))
+    r = R.from_euler('y', np.arctan2(1.0, np.sqrt(2)))
+    cubes.append(r.apply(cubes[1]))
+    r = R.from_euler('y', 45, degrees=True)
+    cubes.append(r.apply(cubes[0]))
+
+    dx = cubes[c0][:, 0].max() - cubes[c1][:, 0].min()
+    cube0 = cubes[c0]
+
+    for delta in [1e8, 1.0, 1e-4, 1e-8, 1e-12]:
+        cube1 = cubes[c1] + np.array([dx + delta, 0, 0])
+        distance, simplex = compute_minimum_distance(cube0, cube1)
+        check_witnesses(distance, simplex)
+        print(distance, delta)
+        assert (np.isclose(distance, delta))
+
+
+def test_random_objects():
+    for i in range(1, 8):
+        for j in range(1, 8):
+            for k in range(1000):
+                arr1 = np.random.rand(i, 3)
+                arr2 = np.random.rand(j, 3)
+                compute_minimum_distance(arr1, arr2)
+
+
+def test_large_random_objects():
+    for i in range(1, 8):
+        for j in range(1, 8):
+            for k in range(1000):
+                arr1 = 10000.0*np.random.rand(i, 3)
+                arr2 = 10000.0*np.random.rand(j, 3)
+                compute_minimum_distance(arr1, arr2)

--- a/include/openGJK/openGJK.h
+++ b/include/openGJK/openGJK.h
@@ -51,6 +51,7 @@ typedef struct gkPolytope_ {
   int numpoints; /*!< Number of points defining the polytope. */
   gkFloat s
       [3]; /*!< Furthest point returned by the support function and updated at each GJK-iteration. For the first iteration this value is a guess - and this guess not irrelevant. */
+  int s_idx; /*!< Index of the furthest point returned by the support function. */
   gkFloat**
       coord; /*!< Coordinates of the points of the polytope. This is owned by user who manages and garbage-collects the memory for these coordinates. */
 } gkPolytope;
@@ -61,6 +62,8 @@ typedef struct gkPolytope_ {
 typedef struct gkSimplex_ {
   int nvrtx;          /*!< Number of points defining the simplex. */
   gkFloat vrtx[4][3]; /*!< Coordinates of the points of the simplex. */
+  int vrtx_idx[4][2];    /*!< Indices of the points of the simplex. */
+  gkFloat witnesses[2][3]; /*!< Coordinates of the witness points. */
 } gkSimplex;
 
 /*! @brief Invoke the GJK algorithm to compute the minimum distance between two polytopes.

--- a/openGJK.c
+++ b/openGJK.c
@@ -356,14 +356,14 @@ inline static void
 S3D(gkSimplex* s, gkFloat* v) {
   gkFloat s1[3], s2[3], s3[3], s4[3], s1s2[3], s1s3[3], s1s4[3];
   gkFloat si[3], sj[3], sk[3];
-  int s1_idx[2];
+  int s1_idx[2], s2_idx[2], s3_idx[2];
   int si_idx[2], sj_idx[2], sk_idx[2];
   int testLineThree, testLineFour, testPlaneTwo, testPlaneThree, testPlaneFour, dotTotal;
   int i, j, k, t;
 
   getvrtxidx(s1, s1_idx, 3);
-  getvrtx(s2, 2);
-  getvrtx(s3, 1);
+  getvrtxidx(s2, s2_idx, 2);
+  getvrtxidx(s3, s3_idx, 1);
   getvrtx(s4, 0);
   calculateEdgeVector(s1s2, s2);
   calculateEdgeVector(s1s3, s3);
@@ -402,26 +402,43 @@ S3D(gkSimplex* s, gkFloat* v) {
       // 1,i,j, are the indices of the points on the triangle and remove k from
       // simplex
       s->nvrtx = 3;
-      if (!testPlaneTwo) { // k = 2;   removes s2
-        for (i = 0; i < 3; i++) {
+      if (!testPlaneTwo)
+      { // k = 2;   removes s2
+        for (i = 0; i < 3; i++)
+        {
           s->vrtx[2][i] = s->vrtx[3][i];
         }
-      } else if (!testPlaneThree) { // k = 1; // removes s3
-        for (i = 0; i < 3; i++) {
+        for (i = 0; i < 2; i++)
+        {
+          s->vrtx_idx[2][i] = s->vrtx_idx[3][i];
+        }
+      }
+      else if (!testPlaneThree)
+      { // k = 1; // removes s3
+        for (i = 0; i < 3; i++)
+        {
           s->vrtx[1][i] = s2[i];
-        }
-        for (i = 0; i < 3; i++) {
           s->vrtx[2][i] = s->vrtx[3][i];
         }
-      } else if (!testPlaneFour) { // k = 0; // removes s4  and no need to reorder
-        for (i = 0; i < 3; i++) {
+        for (i = 0; i < 2; i++)
+        {
+          s->vrtx_idx[1][i] = s2_idx[i];
+          s->vrtx_idx[2][i] = s->vrtx_idx[3][i];
+        }
+      }
+      else if (!testPlaneFour)
+      { // k = 0; // removes s4  and no need to reorder
+        for (i = 0; i < 3; i++)
+        {
           s->vrtx[0][i] = s3[i];
-        }
-        for (i = 0; i < 3; i++) {
           s->vrtx[1][i] = s2[i];
-        }
-        for (i = 0; i < 3; i++) {
           s->vrtx[2][i] = s->vrtx[3][i];
+        }
+        for (i = 0; i < 2; i++)
+        {
+          s->vrtx_idx[0][i] = s3_idx[i];
+          s->vrtx_idx[1][i] = s2_idx[i];
+          s->vrtx_idx[2][i] = s->vrtx_idx[3][i];
         }
       }
       // Call S2D

--- a/openGJK.c
+++ b/openGJK.c
@@ -59,54 +59,91 @@
   s->nvrtx = 3;                                                                                                        \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[2][t] = s->vrtx[3][t];                                                                                     \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[2][t] = s->vrtx_idx[3][t];                                                                             \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[1][t] = si[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[1][t] = si_idx[t];                                                                                     \
   for (t = 0; t < 3; t++)                                                                                              \
-    s->vrtx[0][t] = sk[t];
+    s->vrtx[0][t] = sk[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[0][t] = sk_idx[t];
 
 #define select_1ij()                                                                                                   \
   s->nvrtx = 3;                                                                                                        \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[2][t] = s->vrtx[3][t];                                                                                     \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[2][t] = s->vrtx_idx[3][t];                                                                             \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[1][t] = si[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[1][t] = si_idx[t];                                                                                     \
   for (t = 0; t < 3; t++)                                                                                              \
-    s->vrtx[0][t] = sj[t];
+    s->vrtx[0][t] = sj[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[0][t] = sj_idx[t];
 
 #define select_1jk()                                                                                                   \
   s->nvrtx = 3;                                                                                                        \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[2][t] = s->vrtx[3][t];                                                                                     \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[2][t] = s->vrtx_idx[3][t];                                                                             \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[1][t] = sj[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[1][t] = sj_idx[t];                                                                                     \
   for (t = 0; t < 3; t++)                                                                                              \
-    s->vrtx[0][t] = sk[t];
+    s->vrtx[0][t] = sk[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[0][t] = sk_idx[t];
 
 #define select_1i()                                                                                                    \
   s->nvrtx = 2;                                                                                                        \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[1][t] = s->vrtx[3][t];                                                                                     \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[1][t] = s->vrtx_idx[3][t];                                                                             \
   for (t = 0; t < 3; t++)                                                                                              \
-    s->vrtx[0][t] = si[t];
+    s->vrtx[0][t] = si[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[0][t] = si_idx[t];
 
 #define select_1j()                                                                                                    \
   s->nvrtx = 2;                                                                                                        \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[1][t] = s->vrtx[3][t];                                                                                     \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[1][t] = s->vrtx_idx[3][t];                                                                             \
   for (t = 0; t < 3; t++)                                                                                              \
-    s->vrtx[0][t] = sj[t];
+    s->vrtx[0][t] = sj[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[0][t] = sj_idx[t];
 
 #define select_1k()                                                                                                    \
   s->nvrtx = 2;                                                                                                        \
   for (t = 0; t < 3; t++)                                                                                              \
     s->vrtx[1][t] = s->vrtx[3][t];                                                                                     \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[1][t] = s->vrtx_idx[3][t];                                                                             \
   for (t = 0; t < 3; t++)                                                                                              \
-    s->vrtx[0][t] = sk[t];
+    s->vrtx[0][t] = sk[t];                                                                                             \
+  for (t = 0; t < 2; t++)                                                                                              \
+    s->vrtx_idx[0][t] = sk_idx[t];
 
 #define getvrtx(point, location)                                                                                       \
   point[0] = s->vrtx[location][0];                                                                                     \
   point[1] = s->vrtx[location][1];                                                                                     \
   point[2] = s->vrtx[location][2];
+
+#define getvrtxidx(point, index, location)                                                                             \
+  point[0] = s->vrtx[location][0];                                                                                     \
+  point[1] = s->vrtx[location][1];                                                                                     \
+  point[2] = s->vrtx[location][2];                                                                                     \
+  index[0] = s->vrtx_idx[location][0];                                                                                 \
+  index[1] = s->vrtx_idx[location][1];
 
 #define calculateEdgeVector(p1p2, p2)                                                                                  \
   p1p2[0] = p2[0] - s->vrtx[3][0];                                                                                     \
@@ -120,7 +157,9 @@
   s->nvrtx = 1;                                                                                                        \
   s->vrtx[0][0] = s->vrtx[1][0];                                                                                       \
   s->vrtx[0][1] = s->vrtx[1][1];                                                                                       \
-  s->vrtx[0][2] = s->vrtx[1][2];
+  s->vrtx[0][2] = s->vrtx[1][2];                                                                                       \
+  s->vrtx_idx[0][0] = s->vrtx_idx[1][0];                                                                               \
+  s->vrtx_idx[0][1] = s->vrtx_idx[1][1];
 
 #define S2Dregion1()                                                                                                   \
   v[0] = s->vrtx[2][0];                                                                                                \
@@ -129,19 +168,25 @@
   s->nvrtx = 1;                                                                                                        \
   s->vrtx[0][0] = s->vrtx[2][0];                                                                                       \
   s->vrtx[0][1] = s->vrtx[2][1];                                                                                       \
-  s->vrtx[0][2] = s->vrtx[2][2];
+  s->vrtx[0][2] = s->vrtx[2][2];                                                                                       \
+  s->vrtx_idx[0][0] = s->vrtx_idx[2][0];                                                                               \
+  s->vrtx_idx[0][1] = s->vrtx_idx[2][1];
 
 #define S2Dregion12()                                                                                                  \
   s->nvrtx = 2;                                                                                                        \
   s->vrtx[0][0] = s->vrtx[2][0];                                                                                       \
   s->vrtx[0][1] = s->vrtx[2][1];                                                                                       \
-  s->vrtx[0][2] = s->vrtx[2][2];
+  s->vrtx[0][2] = s->vrtx[2][2];                                                                                       \
+  s->vrtx_idx[0][0] = s->vrtx_idx[2][0];                                                                               \
+  s->vrtx_idx[0][1] = s->vrtx_idx[2][1];
 
 #define S2Dregion13()                                                                                                  \
   s->nvrtx = 2;                                                                                                        \
   s->vrtx[1][0] = s->vrtx[2][0];                                                                                       \
   s->vrtx[1][1] = s->vrtx[2][1];                                                                                       \
-  s->vrtx[1][2] = s->vrtx[2][2];
+  s->vrtx[1][2] = s->vrtx[2][2];                                                                                       \
+  s->vrtx_idx[1][0] = s->vrtx_idx[2][0];                                                                               \
+  s->vrtx_idx[1][1] = s->vrtx_idx[2][1];
 
 #define S3Dregion1()                                                                                                   \
   v[0] = s1[0];                                                                                                        \
@@ -150,7 +195,9 @@
   s->nvrtx = 1;                                                                                                        \
   s->vrtx[0][0] = s1[0];                                                                                               \
   s->vrtx[0][1] = s1[1];                                                                                               \
-  s->vrtx[0][2] = s1[2];
+  s->vrtx[0][2] = s1[2];                                                                                               \
+  s->vrtx_idx[0][0] = s1_idx[0];                                                                                       \
+  s->vrtx_idx[0][1] = s1_idx[1];
 
 inline static gkFloat
 determinant(const gkFloat* restrict p, const gkFloat* restrict q, const gkFloat* restrict r) {
@@ -309,10 +356,12 @@ inline static void
 S3D(gkSimplex* s, gkFloat* v) {
   gkFloat s1[3], s2[3], s3[3], s4[3], s1s2[3], s1s3[3], s1s4[3];
   gkFloat si[3], sj[3], sk[3];
+  int s1_idx[2];
+  int si_idx[2], sj_idx[2], sk_idx[2];
   int testLineThree, testLineFour, testPlaneTwo, testPlaneThree, testPlaneFour, dotTotal;
   int i, j, k, t;
 
-  getvrtx(s1, 3);
+  getvrtxidx(s1, s1_idx, 3);
   getvrtx(s2, 2);
   getvrtx(s3, 1);
   getvrtx(s4, 0);
@@ -400,9 +449,9 @@ S3D(gkSimplex* s, gkFloat* v) {
         j = 1;
       }
 
-      getvrtx(si, i);
-      getvrtx(sj, j);
-      getvrtx(sk, k);
+      getvrtxidx(si, si_idx, i);
+      getvrtxidx(sj, sj_idx, j);
+      getvrtxidx(sk, sk_idx, k);
 
       if (dotTotal == 1) {
         if (hff1_tests[k]) {
@@ -536,9 +585,9 @@ S3D(gkSimplex* s, gkFloat* v) {
           i = 2; // s2
           j = 1;
         }
-        getvrtx(si, i);
-        getvrtx(sj, j);
-        getvrtx(sk, k);
+        getvrtxidx(si, si_idx, i);
+        getvrtxidx(sj, sj_idx, j);
+        getvrtxidx(sk, sk_idx, k);
 
         if (!hff2(s1, si, sj)) {
           select_1ij();
@@ -566,9 +615,9 @@ S3D(gkSimplex* s, gkFloat* v) {
           i = 2; // s2
           j = 1;
         }
-        getvrtx(si, i);
-        getvrtx(sj, j);
-        getvrtx(sk, k);
+        getvrtxidx(si, si_idx, i);
+        getvrtxidx(sj, sj_idx, j);
+        getvrtxidx(sk, sk_idx, k);
 
         if (!hff2(s1, sj, sk)) {
           if (!hff2(s1, sk, sj)) {
@@ -616,6 +665,7 @@ support(gkPolytope* restrict body, const gkFloat* restrict v) {
     body->s[0] = body->coord[better][0];
     body->s[1] = body->coord[better][1];
     body->s[2] = body->coord[better][2];
+    body->s_idx = better;
   }
 }
 
@@ -636,6 +686,259 @@ subalgorithm(gkSimplex* s, gkFloat* v) {
   }
 }
 
+inline static void W0D(const gkPolytope *bd1, const gkPolytope *bd2, gkSimplex *smp)
+{
+  const gkFloat *w00 = bd1->coord[smp->vrtx_idx[0][0]];
+  const gkFloat *w01 = bd2->coord[smp->vrtx_idx[0][1]];
+  for (int t = 0; t < 3; t++)
+  {
+    smp->witnesses[0][t] = w00[t];
+    smp->witnesses[1][t] = w01[t];
+  }
+}
+
+inline static void W1D(const gkPolytope *bd1, const gkPolytope *bd2, gkSimplex *smp)
+{
+  gkFloat pq[3], po[3];
+
+  const gkFloat *p = smp->vrtx[0];
+  const gkFloat *q = smp->vrtx[1];
+
+  for (int t = 0; t < 3; t++)
+  {
+    pq[t] = q[t] - p[t];
+    po[t] = -p[t];
+  }
+
+  // Compute barycentric coordinates via matrix inversion
+  // (in the linear case the matrix is 1x1 thus simplified)
+  const gkFloat det = dotProduct(pq, pq);
+  if(det == 0.0){
+    // Degenerate case
+    W0D(bd1, bd2, smp);
+  }
+
+  const gkFloat a1 = dotProduct(pq, po) / det;
+  const gkFloat a0 = 1.0 - a1;
+
+  // Compute witness points
+  const gkFloat *w00 = bd1->coord[smp->vrtx_idx[0][0]];
+  const gkFloat *w01 = bd2->coord[smp->vrtx_idx[0][1]];
+  const gkFloat *w10 = bd1->coord[smp->vrtx_idx[1][0]];
+  const gkFloat *w11 = bd2->coord[smp->vrtx_idx[1][1]];
+  for (int t = 0; t < 3; t++)
+  {
+    smp->witnesses[0][t] = w00[t] * a0 + w10[t] * a1;
+    smp->witnesses[1][t] = w01[t] * a0 + w11[t] * a1;
+  }
+}
+
+inline static void W2D(const gkPolytope* bd1, const gkPolytope* bd2, gkSimplex* smp)
+{
+  gkFloat pq[3], pr[3], po[3];
+
+  const gkFloat* p = smp->vrtx[0];
+  const gkFloat* q = smp->vrtx[1];
+  const gkFloat* r = smp->vrtx[2];
+
+  for(int t=0; t < 3; t++){
+    pq[t] = q[t] - p[t];
+    pr[t] = r[t] - p[t];
+    po[t] = -p[t];
+  }
+
+  // Compute barycentric coordinates via matrix inversion
+  // TODO add Latex explaining what is going on
+  const gkFloat M00 = dotProduct(pq, pq);
+  const gkFloat M01 = dotProduct(pq, pr);
+  const gkFloat M11 = dotProduct(pr, pr);
+  const gkFloat det = M00 * M11 - M01 * M01;
+  if(det == 0.0){
+    // Degenerate case
+    W1D(bd1, bd2, smp);
+  }
+
+  const gkFloat b0 = dotProduct(pq, po);
+  const gkFloat b1 = dotProduct(pr, po);
+  const gkFloat I00 = M11 / det;
+  const gkFloat I01 = -M01 / det;
+  const gkFloat I11 = M00 / det;
+  const gkFloat a1 = I00 * b0 + I01 * b1;
+  const gkFloat a2 = I01 * b0 + I11 * b1;
+  const gkFloat a0 = 1.0 - a1 - a2;
+
+  if (a0 < gkEpsilon)
+  {
+    smp->nvrtx = 2;
+    smp->vrtx[0][0] = smp->vrtx[2][0];
+    smp->vrtx[0][1] = smp->vrtx[2][1];
+    smp->vrtx[0][2] = smp->vrtx[2][2];
+    smp->vrtx_idx[0][0] = smp->vrtx_idx[2][0];
+    smp->vrtx_idx[0][1] = smp->vrtx_idx[2][1];
+    W1D(bd1, bd2, smp);
+  }
+  else if (a1 < gkEpsilon)
+  {
+    smp->nvrtx = 2;
+    smp->vrtx[1][0] = smp->vrtx[2][0];
+    smp->vrtx[1][1] = smp->vrtx[2][1];
+    smp->vrtx[1][2] = smp->vrtx[2][2];
+    smp->vrtx_idx[1][0] = smp->vrtx_idx[2][0];
+    smp->vrtx_idx[1][1] = smp->vrtx_idx[2][1];
+    W1D(bd1, bd2, smp);
+  }
+  else if (a2 < gkEpsilon)
+  {
+    smp->nvrtx = 2;
+    W1D(bd1, bd2, smp);
+  }
+
+  // Compute witness points
+  // This is done by blending the original points using
+  // the barycentric coordinates
+  const gkFloat* w00 = bd1->coord[smp->vrtx_idx[0][0]];
+  const gkFloat* w01 = bd2->coord[smp->vrtx_idx[0][1]];
+  const gkFloat* w10 = bd1->coord[smp->vrtx_idx[1][0]];
+  const gkFloat* w11 = bd2->coord[smp->vrtx_idx[1][1]];
+  const gkFloat* w20 = bd1->coord[smp->vrtx_idx[2][0]];
+  const gkFloat* w21 = bd2->coord[smp->vrtx_idx[2][1]];
+  for(int t=0; t < 3; t++){
+    smp->witnesses[0][t] = w00[t] * a0 + w10[t] * a1 + w20[t] * a2;
+    smp->witnesses[1][t] = w01[t] * a0 + w11[t] * a1 + w21[t] * a2;
+  }
+}
+
+inline static void W3D(const gkPolytope *bd1, const gkPolytope *bd2, gkSimplex *smp)
+{
+  gkFloat pq[3], pr[3], ps[3], po[3];
+
+  const gkFloat *p = smp->vrtx[0];
+  const gkFloat *q = smp->vrtx[1];
+  const gkFloat *r = smp->vrtx[2];
+  const gkFloat *s = smp->vrtx[3];
+
+  for (int t = 0; t < 3; t++)
+  {
+    pq[t] = q[t] - p[t];
+    pr[t] = r[t] - p[t];
+    ps[t] = s[t] - p[t];
+    po[t] = -p[t];
+  }
+
+  // Compute barycentric coordinates via matrix inversion
+  // TODO add Latex explaining what is going on
+  const gkFloat M00 = dotProduct(pq, pq);
+  const gkFloat M01 = dotProduct(pq, pr);
+  const gkFloat M02 = dotProduct(pq, ps);
+  const gkFloat M11 = dotProduct(pr, pr);
+  const gkFloat M12 = dotProduct(pr, ps);
+  const gkFloat M22 = dotProduct(ps, ps);
+  const gkFloat det00 = M11 * M22 - M12 * M12;
+  const gkFloat det01 = M01 * M22 - M02 * M12;
+  const gkFloat det02 = M01 * M12 - M02 * M11;
+  const gkFloat det = M00 * det00 - M01 * det01 + M02 * det02;
+  if (det == 0.0)
+  {
+    // Degenerate case
+    W2D(bd1, bd2, smp);
+  }
+
+  const gkFloat b0 = dotProduct(pq, po);
+  const gkFloat b1 = dotProduct(pr, po);
+  const gkFloat b2 = dotProduct(ps, po);
+
+  // inverse matrix
+  // (the matrix is symmetric, so we can use the cofactor matrix)
+  const gkFloat det11 = M00 * M22 - M02 * M02;
+  const gkFloat det12 = M00 * M12 - M01 * M02;
+  const gkFloat det22 = M00 * M11 - M01 * M01;
+  const gkFloat I00 = det00 / det;
+  const gkFloat I01 = -det01 / det;
+  const gkFloat I02 = det02 / det;
+  const gkFloat I11 = det11 / det;
+  const gkFloat I12 = -det12 / det;
+  const gkFloat I22 = det22 / det;
+
+  const gkFloat a1 = I00 * b0 + I01 * b1 + I02 * b2;
+  const gkFloat a2 = I01 * b0 + I11 * b1 + I12 * b2;
+  const gkFloat a3 = I02 * b0 + I12 * b1 + I22 * b2;
+  const gkFloat a0 = 1.0 - a1 - a2 - a3;
+
+  if (a0 < gkEpsilon)
+  {
+    smp->nvrtx = 3;
+    smp->vrtx[0][0] = smp->vrtx[3][0];
+    smp->vrtx[0][1] = smp->vrtx[3][1];
+    smp->vrtx[0][2] = smp->vrtx[3][2];
+    smp->vrtx_idx[0][0] = smp->vrtx_idx[3][0];
+    smp->vrtx_idx[0][1] = smp->vrtx_idx[3][1];
+    W2D(bd1, bd2, smp);
+  }
+  else if (a1 < gkEpsilon)
+  {
+    smp->nvrtx = 3;
+    smp->vrtx[1][0] = smp->vrtx[3][0];
+    smp->vrtx[1][1] = smp->vrtx[3][1];
+    smp->vrtx[1][2] = smp->vrtx[3][2];
+    smp->vrtx_idx[1][0] = smp->vrtx_idx[3][0];
+    smp->vrtx_idx[1][1] = smp->vrtx_idx[3][1];
+    W2D(bd1, bd2, smp);
+  }
+  else if (a2 < gkEpsilon)
+  {
+    smp->nvrtx = 3;
+    smp->vrtx[2][0] = smp->vrtx[3][0];
+    smp->vrtx[2][1] = smp->vrtx[3][1];
+    smp->vrtx[2][2] = smp->vrtx[3][2];
+    smp->vrtx_idx[2][0] = smp->vrtx_idx[3][0];
+    smp->vrtx_idx[2][1] = smp->vrtx_idx[3][1];
+    W2D(bd1, bd2, smp);
+  }
+  else if(a3 < gkEpsilon)
+  {
+    smp->nvrtx = 3;
+    W2D(bd1, bd2, smp);
+  }
+
+  // Compute witness points
+  // This is done by blending the original points using
+  // the barycentric coordinates
+  const gkFloat *w00 = bd1->coord[smp->vrtx_idx[0][0]];
+  const gkFloat *w01 = bd2->coord[smp->vrtx_idx[0][1]];
+  const gkFloat *w10 = bd1->coord[smp->vrtx_idx[1][0]];
+  const gkFloat *w11 = bd2->coord[smp->vrtx_idx[1][1]];
+  const gkFloat *w20 = bd1->coord[smp->vrtx_idx[2][0]];
+  const gkFloat *w21 = bd2->coord[smp->vrtx_idx[2][1]];
+  const gkFloat *w30 = bd1->coord[smp->vrtx_idx[3][0]];
+  const gkFloat *w31 = bd2->coord[smp->vrtx_idx[3][1]];
+  for (int t = 0; t < 3; t++)
+  {
+    smp->witnesses[0][t] = w00[t] * a0 + w10[t] * a1 + w20[t] * a2 + w30[t] * a3;
+    smp->witnesses[1][t] = w01[t] * a0 + w11[t] * a1 + w21[t] * a2 + w31[t] * a3;
+  }
+}
+
+inline static void
+compute_witnesses(const gkPolytope* bd1, const gkPolytope* bd2, gkSimplex* smp)
+{
+  switch(smp->nvrtx){
+    case 4:
+      W3D(bd1, bd2, smp);
+      break;
+    case 3:
+      W2D(bd1, bd2, smp);
+      break;
+    case 2:
+      W1D(bd1, bd2, smp);
+      break;
+    case 1:
+      W0D(bd1, bd2, smp);
+      break;
+    default:
+      mexPrintf("\nERROR:\t invalid simplex\n");
+  }
+}
+
 gkFloat
 compute_minimum_distance(gkPolytope bd1, gkPolytope bd2, gkSimplex* restrict s) {
   unsigned int k = 0;                /**< Iteration counter                 */
@@ -646,6 +949,7 @@ compute_minimum_distance(gkPolytope bd1, gkPolytope bd2, gkSimplex* restrict s) 
   const gkFloat eps_rel2 = eps_rel * eps_rel;
   unsigned int i;
   gkFloat w[3];
+  int w_idx[2];
   gkFloat v[3];
   gkFloat vminus[3];
   gkFloat norm2Wmax = 0;
@@ -655,19 +959,26 @@ compute_minimum_distance(gkPolytope bd1, gkPolytope bd2, gkSimplex* restrict s) 
   v[1] = bd1.coord[0][1] - bd2.coord[0][1];
   v[2] = bd1.coord[0][2] - bd2.coord[0][2];
 
-  /* Inialise simplex */
+  /* Initialise simplex */
   s->nvrtx = 1;
   for (int t = 0; t < 3; ++t) {
     s->vrtx[0][t] = v[t];
   }
 
+  s->vrtx_idx[0][0] = 0;
+  s->vrtx_idx[0][1] = 0;
+
   for (int t = 0; t < 3; ++t) {
     bd1.s[t] = bd1.coord[0][t];
   }
 
+  bd1.s_idx = 0;
+
   for (int t = 0; t < 3; ++t) {
     bd2.s[t] = bd2.coord[0][t];
   }
+
+  bd2.s_idx = 0;
 
   /* Begin GJK iteration */
   do {
@@ -684,6 +995,8 @@ compute_minimum_distance(gkPolytope bd1, gkPolytope bd2, gkSimplex* restrict s) 
     for (int t = 0; t < 3; ++t) {
       w[t] = bd1.s[t] - bd2.s[t];
     }
+    w_idx[0] = bd1.s_idx;
+    w_idx[1] = bd2.s_idx;
 
     /* Test first exit condition (new point already in simplex/can't move
      * further) */
@@ -701,6 +1014,8 @@ compute_minimum_distance(gkPolytope bd1, gkPolytope bd2, gkSimplex* restrict s) 
     for (int t = 0; t < 3; ++t) {
       s->vrtx[i][t] = w[t];
     }
+    s->vrtx_idx[i][0] = w_idx[0];
+    s->vrtx_idx[i][1] = w_idx[1];
     s->nvrtx++;
 
     /* Invoke distance sub-algorithm */
@@ -725,6 +1040,7 @@ compute_minimum_distance(gkPolytope bd1, gkPolytope bd2, gkSimplex* restrict s) 
               " * * * * * * * * * * * * * * \n");
   }
 
+  compute_witnesses(&bd1, &bd2, s);
   return sqrt(norm2(v));
 }
 


### PR DESCRIPTION
This PR adds the bookkeeping and barycentric coordinate calculations to support witness points in addition to the raw distance. In addition, it adds a ctypes interface which supports the full C interface from Python.

Resolves #2 
Resolves #4 
